### PR TITLE
This commit addresses two issues with the mixer component:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local development
+dev_server.log
+jules-scratch/

--- a/components/beat-sequencer.tsx
+++ b/components/beat-sequencer.tsx
@@ -127,6 +127,10 @@ export function BeatSequencer() {
 
   // Initialize Tone.js and create synthetic drum sounds
   useEffect(() => {
+    // When the kit changes, we need to reset the samples loaded flag
+    setSamplesLoaded(false)
+    setTrackSettings(INITIAL_TRACK_SETTINGS)
+
     let mounted = true
 
     const initializeAudio = async () => {
@@ -270,7 +274,7 @@ export function BeatSequencer() {
         }
       })
     }
-  }, [selectedKit]) // Empty dependency array to run only once
+  }, [selectedKit, handleTrackSettingChange])
 
   // Separate useEffect to update the sequence callback when pattern or metronome changes
   useEffect(() => {


### PR DESCRIPTION
1.  **Unresponsive Sliders**: The mixer sliders were not responding to user input. This was caused by a missing dependency in the `useEffect` hook that initializes the audio, which prevented the `handleTrackSettingChange` function from being updated with the latest state.

2.  **Mixer Reset on Kit Change**: The mixer settings were not being reset when the drum kit was changed. This has been fixed by explicitly resetting the `trackSettings` state to their initial values when a new kit is selected.

Extraneous files have been removed from the changeset, and the `.gitignore` file has been updated to prevent similar issues in the future.