### PR TITLE
Fix MIDI export timing for simultaneous hits

### DIFF
--- a/components/beat-sequencer.tsx
+++ b/components/beat-sequencer.tsx
@@ -816,30 +816,37 @@ export function BeatSequencer() {
       let currentTick = 0
       for (let step = 0; step < STEPS; step++) {
         const stepTick = step * ticksPerStep
-        const deltaTime = stepTick - currentTick
+        let stepHasNoteOn = false
 
         pattern.forEach((track, trackIndex) => {
           if (track[step]) {
             const soundName = SAMPLES[trackIndex].name.toLowerCase() as keyof typeof drumNotes
             const note = drumNotes[soundName]
 
+            // Calculate delta so additional notes in the same step fire simultaneously
+            const noteOnDelta = stepHasNoteOn ? 0 : stepTick - currentTick
+
             // Add note on event
             events.push(
-              ...encodeVariableLength(deltaTime),
+              ...encodeVariableLength(noteOnDelta),
               0x99, // Note on, channel 10 (drums)
               note,
               100, // Velocity
             )
 
+            stepHasNoteOn = true
+
+            const noteDuration = 60
+
             // Add note off event after short duration
             events.push(
-              ...encodeVariableLength(60), // Short duration
+              ...encodeVariableLength(noteDuration),
               0x89, // Note off, channel 10
               note,
               0, // Velocity
             )
 
-            currentTick = stepTick + 60
+            currentTick = stepTick + noteDuration
           }
         })
       }


### PR DESCRIPTION
## Summary
- ensure exportMIDI uses zero delta times when multiple tracks fire on the same step
- update MIDI tick bookkeeping so note-off durations advance the timeline without offsetting later note-ons

## Testing
- node script verifying note-on deltas for simultaneous hits

------
https://chatgpt.com/codex/tasks/task_e_68ff815b1f70832fa814cb58c1a897d7