### PR TITLE
Improve step selection accuracy for sequencer canvas

### DIFF
--- a/components/beat-sequencer/sequencer-canvas.tsx
+++ b/components/beat-sequencer/sequencer-canvas.tsx
@@ -154,7 +154,8 @@ export function SequencerCanvas({
     let angle = Math.atan2(dy, dx) + Math.PI / 2
     if (angle < 0) angle += Math.PI * 2
 
-    const stepIndex = Math.floor((angle / (Math.PI * 2)) * STEPS) % STEPS
+    const normalizedAngle = angle / (Math.PI * 2)
+    const stepIndex = Math.round(normalizedAngle * STEPS) % STEPS
 
     for (let trackIndex = 0; trackIndex < SAMPLES.length; trackIndex++) {
       const trackRadius = maxRadius * (0.9 - trackIndex * 0.15)


### PR DESCRIPTION
## Summary
- adjust the sequencer canvas hit detection to round to the nearest step center before toggling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ff8c32ea80832f8fe14c583ff7589b