### PR TITLE
Automate backlog issue creation from repo files

### DIFF
--- a/.github/issues/keep-audio-engine-running-while-updating-tempo-and-swing.md
+++ b/.github/issues/keep-audio-engine-running-while-updating-tempo-and-swing.md
@@ -1,0 +1,14 @@
+# Keep audio engine running while updating tempo and swing
+
+## Summary
+Changing the tempo or swing currently retriggers the heavy audio initialization effect in `hooks/use-beat-sequencer.ts`, which tears down and rebuilds the entire Tone.js graph. This causes playback to pause and the loading UI to flash on every small adjustment. We should keep the transport update lightweight so that tempo and swing tweaks remain smooth.
+
+## Acceptance Criteria
+- Audio initialization only runs when the selected kit changes, not when tempo or swing is updated.
+- Existing effects continue to keep the Tone.Transport BPM and swing values synchronized with state changes.
+- Adjusting tempo or swing while audio is playing no longer pauses playback or shows the loading indicator.
+
+## Implementation Notes
+- Narrow the dependency list for the audio initialization effect in `hooks/use-beat-sequencer.ts` and guard it with a kit reference.
+- Verify that the dedicated effects that update BPM and swing still cover all update paths after the dependency change.
+- Manually test playback while adjusting tempo and swing to confirm the transport keeps running smoothly.

--- a/.github/issues/surface-audio-initialization-failures.md
+++ b/.github/issues/surface-audio-initialization-failures.md
@@ -1,0 +1,14 @@
+# Surface audio initialization failures
+
+## Summary
+When audio setup throws inside `hooks/use-beat-sequencer.ts`, the catch block currently sets `samplesLoaded` to `true`. The UI only displays the error message while `samplesLoaded` is `false`, so the failure disappears without feedback. Users just see the loader vanish with the transport stopped.
+
+## Acceptance Criteria
+- Failing to initialize audio leaves the UI in an error state so the "Error initializing audio" message is visible.
+- The normal loaded path is not re-entered after a failure unless a retry succeeds.
+- (Optional) Provide guidance or a retry mechanism if initialization cannot proceed.
+
+## Implementation Notes
+- Update the failure handling logic in `hooks/use-beat-sequencer.ts` to avoid setting `samplesLoaded` to `true` when initialization fails.
+- Confirm the `BeatSequencer` component renders the existing error message when an initialization error occurs.
+- Consider whether a retry button or instructions are helpful after an error.

--- a/.github/workflows/create-issues-from-files.yml
+++ b/.github/workflows/create-issues-from-files.yml
@@ -1,0 +1,31 @@
+name: Create GitHub issues from files
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    strategy:
+      matrix:
+        issue:
+          - title: "Keep audio engine running while updating tempo and swing"
+            file: .github/issues/keep-audio-engine-running-while-updating-tempo-and-swing.md
+          - title: "Surface audio initialization failures"
+            file: .github/issues/surface-audio-initialization-failures.md
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Create or update GitHub issue
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: ${{ matrix.issue.title }}
+          content-filepath: ${{ matrix.issue.file }}
+          labels: enhancement
+          update-existing: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that creates or updates GitHub issues from the stored markdown backlog files whenever changes reach main
- apply the standard `enhancement` label to the generated issues so they are easy to track

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_69069381dc60832fa89ba486b2b9792c