### PR TITLE
Fix mixer card background alpha

### DIFF
--- a/components/mixer.tsx
+++ b/components/mixer.tsx
@@ -24,13 +24,22 @@ interface MixerProps {
   trackColors: ReadonlyArray<string>
 }
 
+const toTranslucent = (color: string) =>
+  color.startsWith("rgb(")
+    ? color.replace("rgb", "rgba").replace(")", ", 0.2)")
+    : `${color}33`
+
 export function Mixer({ trackSettings, handleTrackSettingChange, samples, trackColors }: MixerProps) {
   return (
     <div className="grid gap-6 mt-4">
       <h2 className="text-xl font-bold text-center">Mixer</h2>
       <div className="grid grid-cols-1 md:grid-cols-5 gap-6">
         {samples.map((sample, trackIndex) => (
-          <div key={trackIndex} className="grid gap-3 p-4 rounded-lg" style={{ backgroundColor: `${trackColors[trackIndex]}33` }}>
+          <div
+            key={trackIndex}
+            className="grid gap-3 p-4 rounded-lg"
+            style={{ backgroundColor: toTranslucent(trackColors[trackIndex]) }}
+          >
             <span className="text-sm font-bold" style={{ color: trackColors[trackIndex] }}>
               {sample.name}
             </span>


### PR DESCRIPTION
## Summary
- ensure mixer cards compute a valid translucent background color from track color
- add a helper that converts rgb strings to rgba fallbacks while still supporting hex values

## Testing
- pnpm test *(fails: ESLint must be installed)*
- pnpm dev --hostname 0.0.0.0 --port 3000 *(manual verification of mixer card tint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913fda19cf4832fa58c950dfc445214)